### PR TITLE
Remove Arduino dependency

### DIFF
--- a/src/mbparser.h
+++ b/src/mbparser.h
@@ -14,8 +14,12 @@ However, it was original implemented for little endian machines.
 */
 #ifndef mbparser_h
 #define  mbparser_h
-#include <Arduino.h>
 
+#define min(a,b) (((a)<(b))?(a):(b))
+#define max(a,b) (((a)>(b))?(a):(b))
+
+#define highByte(w) (w >> 8)
+#define lowByte(w) (w & 0xFF)
 
 // Endian Literals
 #ifndef LITTLE_ENDIAN

--- a/src/mbparser.h
+++ b/src/mbparser.h
@@ -39,7 +39,7 @@ class ModbusParser;
   typedef std::function<void(RequestParser *parser)> RequestCallback;
 #else
   typedef void(*ResponseCallback)(ResponseParser *parser);
-  typedef void(*RequestCallback)(ResponseParser *parser);
+  typedef void(*RequestCallback)(RequestParser *parser);
 #endif
 
 // General used enums


### PR DESCRIPTION
Many thanks to @cloadata for this lightweight and efficient library !

This pull request adds definitions for max, min, highByte and lowByte so as to no longer require the Arduino headers
It also fixes a compile error when not using STD_FUNCTIONAL in the definition of RequestCallback

This allows the library to be used on non-Arduino environments and has been tested with a small Linux application. I am personally using it to analyze communications (both ways) between a Schneider EM5 energy meter and its LAN gateway (EER31800)